### PR TITLE
Improved handling of error conditions, logging, test ordering

### DIFF
--- a/README
+++ b/README
@@ -13,7 +13,7 @@
 ### RUNNING / USING
 
 Pass `--gevented-processes` option to Nose or set `NOSE_GEVENTED_PROCESSES` env var to the number of worker processes you want to have.
-Setting a positive number will give you exactly that number of workers. Setting a negative number will make the plugin detect the number of CPUs and use that many workers.
+Setting a positive number will give you exactly that number of workers. Setting -1 will make the plugin detect the number of CPUs and use that many workers. Setting -2, -3, etc. will make the plugin use all CPU cores minus (-1 -(gevented_processes)) (i.e. -2 is all but one, -3 is all but two, etc.)
 Default value is zero - meaning the plug in is not used.
 
 Example:

--- a/nose_gevented_multiprocess/__init__.py
+++ b/nose_gevented_multiprocess/__init__.py
@@ -2,10 +2,13 @@ __author__ = 'Daniel Dotsenko'
 __versioninfo__ = (0, 1, 2)
 __version__ = '.'.join(map(str, __versioninfo__))
 
-from .nose_gevented_multiprocess import individual_client_starter, GeventedMultiProcess,\
-    BaseTaskRunner
+from .nose_gevented_multiprocess import (
+    individual_client_starter,
+    GeventedMultiProcess,
+    BaseTaskRunner,
+)
 
 
 __all__ = [
-    'individual_client_starter', 'GeventedMultiProcess'
+    'individual_client_starter', 'GeventedMultiProcess', 'BaseTaskRunner',
 ]

--- a/nose_gevented_multiprocess/nose_gevented_multiprocess.py
+++ b/nose_gevented_multiprocess/nose_gevented_multiprocess.py
@@ -530,7 +530,8 @@ class TestsQueueManager(JSONPRCWSGIApplication):
     This is a "web"(WSGI) application whose methods are exposed as JSON-RPC methods
     """
 
-    def __init__(self, tasks_queue=None, results_queue=None, loader_class=None, result_class=None, config=None):
+    def __init__(self, tasks_queue=None, results_queue=None, loader_class=None,
+                 result_class=None, config=None, task_times={}):
         """
         :param tasks_queue: list of task-describing objects to do
         :type tasks_queue: list or tuple
@@ -549,7 +550,7 @@ class TestsQueueManager(JSONPRCWSGIApplication):
         self.results_processor = None
         self.run_clients_event = gevent.event.Event()
         self.task_starts = {}
-        self.task_times = {}
+        self.task_times = task_times
 
         self['get_setup_objects'] = self._get_nose_set_up_objects
 
@@ -971,7 +972,7 @@ class GeventedMultiProcessTestRunner(TextTestRunner):
                 task_times = pickle.load(open(self.config.options.gevented_timing_file, 'r'))
             except:
                 log.debug('No task times to read for sorting.')
-                task_times = None
+                task_times = {}
             if task_times:
                 log.debug('Unsorted tasks: {}'.format(tasks_queue))
                 tasks_queue.sort(
@@ -983,7 +984,8 @@ class GeventedMultiProcessTestRunner(TextTestRunner):
             tasks_queue,
             loader_class=self.loaderClass,
             result_class=result.__class__,
-            config=self.config
+            config=self.config,
+            task_times=task_times
         )
         server = WSGIServer(queue_manager)
         server_port = server.start()

--- a/nose_gevented_multiprocess/nose_gevented_multiprocess.py
+++ b/nose_gevented_multiprocess/nose_gevented_multiprocess.py
@@ -1067,9 +1067,7 @@ class GeventedMultiProcessTestRunner(TextTestRunner):
         for case in to_teardown:
             try:
                 case.tearDown()
-            except (KeyboardInterrupt, SystemExit):
-                raise
-            except:
+            except Exception:
                 result.addError(case, sys.exc_info())
 
         stop = time.time()

--- a/nose_gevented_multiprocess/nose_gevented_multiprocess.py
+++ b/nose_gevented_multiprocess/nose_gevented_multiprocess.py
@@ -794,14 +794,14 @@ class GeventedMultiProcess(Plugin):
         except (AttributeError, TypeError, ValueError):
             workers = 0
 
-        if workers and _gevent_patch():
+        if workers < 0:
+            workers = multiprocessing.cpu_count()
+
+        if workers > 1 and _gevent_patch():
             self.enabled = True
         else:
             self.enabled = False
             return
-
-        if workers < 0:
-            workers = multiprocessing.cpu_count()
 
         self.config = config
 

--- a/nose_gevented_multiprocess/nose_gevented_multiprocess.py
+++ b/nose_gevented_multiprocess/nose_gevented_multiprocess.py
@@ -979,6 +979,8 @@ class GeventedMultiProcessTestRunner(TextTestRunner):
                     key=lambda t: task_times.get(get_task_key(t), 0),
                     reverse=True)
                 log.debug('Sorted tasks: {}'.format(tasks_queue))
+        else:
+            task_times = {}
 
         queue_manager = TestsQueueManager(
             tasks_queue,

--- a/nose_gevented_multiprocess/nose_gevented_multiprocess.py
+++ b/nose_gevented_multiprocess/nose_gevented_multiprocess.py
@@ -168,7 +168,7 @@ CLIENT_RUNNER_FILE_NAME = 'nose_gevented_multiprocess_runner'
 # each worker process
 _instantiate_plugins = None
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('nose.plugins.nose_gevented_multiprocess')
 
 # log.setLevel(logging.INFO)
 # console = logging.StreamHandler()

--- a/nose_gevented_multiprocess/nose_gevented_multiprocess.py
+++ b/nose_gevented_multiprocess/nose_gevented_multiprocess.py
@@ -145,6 +145,7 @@ def _gevent_patch():
     gevent.monkey.patch_subprocess()
     return True
 
+
 try:
     # 2.7+
     from unittest.runner import _WritelnDecorator
@@ -1111,7 +1112,8 @@ class GeventedMultiProcessTestRunner(TextTestRunner):
             # self.stream.write("get batch return 1\n")
             return
 
-        if (isinstance(test, ContextSuite) and test.hasFixtures(can_split_flag_set)) \
+        if (isinstance(test, ContextSuite)
+            and test.hasFixtures(can_split_flag_set)) \
            or not getattr(test, 'can_split', True) \
            or not isinstance(test, unittest.TestSuite):
             # regular test case, or a suite with context fixtures
@@ -1163,6 +1165,7 @@ def individual_client_starter():
     print("Starting test runner client #%s (talking to server on port %s)" %
           (worker_id, server_port))
     start_test_processor_task_runner(worker_id, server_port)
+
 
 if __name__ == "__main__":
     individual_client_starter()

--- a/nose_gevented_multiprocess/nose_gevented_multiprocess.py
+++ b/nose_gevented_multiprocess/nose_gevented_multiprocess.py
@@ -595,11 +595,12 @@ class TestsQueueManager(JSONPRCWSGIApplication):
                                 timeout=self.config.options.gevented_timeout)  # <-- this blocks!!!
 
             if not ready:
-                log.warning('Timing out with {} remaining tasks; do you need '
-                            'to increase gevented-timeout or investigate a '
-                            'hung test?'.format(len(remaining_tasks)))
-                log.warning('Remaining tasks: {}'.format(remaining_tasks))
-                break
+                raise Exception('Timing out with {} remaining tasks; do you '
+                                'need to increase gevented-timeout or '
+                                'investigate a hung test?\n'
+                                'Remaining tasks: {}'.format(
+                                    len(remaining_tasks),
+                                    remaining_tasks))
 
             if ready[0] == self.run_clients_event and self.results_queue.empty():
                 log.warning('Tasks remaining after all workers finished!')

--- a/nose_gevented_multiprocess/nose_gevented_multiprocess.py
+++ b/nose_gevented_multiprocess/nose_gevented_multiprocess.py
@@ -537,15 +537,16 @@ def run_clients(number_of_clients, server_port, stop_event):
                                 cwd=cwd, **popen_kwargs)
         for worker_id in xrange(number_of_clients)
     ]
-    for waited in gevent.iwait(clients + [stop_event]):
-        if waited is stop_event:
-            # Clean up by terminating the clients
-            for client in clients:
-                ensure_client_terminated(client)
-
-            break
-        else:
-            log.info("Client %s exiting" % waited)
+    try:
+        for waited in gevent.iwait(clients + [stop_event]):
+            if waited is stop_event:
+                # Just clean up
+                break
+            else:
+                log.info("Client %s exiting" % waited)
+    finally:
+        for client in clients:
+            ensure_client_terminated(client)
 
     duration = time.time()-t1
     log.info("%s clients served within %.2f s." %

--- a/nose_gevented_multiprocess/nose_gevented_multiprocess.py
+++ b/nose_gevented_multiprocess/nose_gevented_multiprocess.py
@@ -686,7 +686,7 @@ class WSGIServer(object):
         self.server = server = gevent.pywsgi.WSGIServer(
             ('localhost', 0),
             self.wsgi_application,
-            log=False
+            log=None
         )
         server.start()
         return server.server_port

--- a/nose_gevented_multiprocess/nose_gevented_multiprocess.py
+++ b/nose_gevented_multiprocess/nose_gevented_multiprocess.py
@@ -818,9 +818,9 @@ class GeventedMultiProcess(Plugin):
             help=("Spread test run among this many processes. "
                   "Set a number equal to the number of processors "
                   "in your machine for best results. "
-                  "Pass a negative number to have the number of "
-                  "processes automatically set to the number of "
-                  "cores. Passing 0 disables parallel "
+                  "Pass -1 to use all cores, and subsequent negative numbers "
+                  "to mean all cores minus that difference. "
+                  "Passing 0 disables parallel "
                   "testing. Default is 0 unless NOSE_GEVENTED_PROCESSES is "
                   "set. [NOSE_GEVENTED_PROCESSES]"))
         parser.add_option(
@@ -860,7 +860,11 @@ class GeventedMultiProcess(Plugin):
             workers = 0
 
         if workers < 0:
-            workers = multiprocessing.cpu_count()
+            # Use 1+ (-1*workers) forks
+            # In other words, -1 means 'all cores', -2 means 'all but 1',
+            # -3 'all but 2', etc. Anything nonsensical means disabled.
+            cpu_count = multiprocessing.cpu_count()
+            workers = (cpu_count + 1) - (-1 * workers)
 
         if workers > 1 and _gevent_patch():
             self.enabled = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+nose
 gevent
 requests
 jsonrpcparts

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
         license='GNU LGPL',
         # py_modules=['nose_gevented_multiprocess'],
         packages=['nose_gevented_multiprocess'],
-        install_requires=['requests', 'gevent', 'jsonrpcparts'],
+        install_requires=['nose', 'requests', 'gevent', 'jsonrpcparts'],
         entry_points={
             'nose.plugins.0.10': [
                 'gevented_multiprocess = '

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import sys
 from setuptools import setup
 
 version = '0.1.3'
@@ -15,7 +14,8 @@ project_home = 'http://github.com/dvdotsenko/nose_gevent_multiprocess'
 if __name__ == "__main__":
     setup(
         name='nose-gevented-multiprocess',
-        description='Gevent-supporting multiprocess plugin for Nose testing framework',
+        description='Gevent-supporting multiprocess plugin for Nose testing '
+                    'framework',
         long_description=long_description,
         version=version,
         author='Daniel Dotsenko',
@@ -25,7 +25,8 @@ if __name__ == "__main__":
         classifiers=[
             "Development Status :: 4 - Beta",
             'Intended Audience :: Developers',
-            'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
+            'License :: OSI Approved :: GNU Library or Lesser General Public '
+            'License (LGPL)',
             'Natural Language :: English',
             'Operating System :: OS Independent',
             'Programming Language :: Python',
@@ -33,17 +34,19 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 2.7",
             'Topic :: Software Development :: Testing'
         ],
-        keywords = ['nose', 'multiprocess', 'gevent'],
-        license = 'GNU LGPL',
+        keywords=['nose', 'multiprocess', 'gevent'],
+        license='GNU LGPL',
         # py_modules=['nose_gevented_multiprocess'],
         packages=['nose_gevented_multiprocess'],
         install_requires=['requests', 'gevent', 'jsonrpcparts'],
         entry_points={
             'nose.plugins.0.10': [
-                'gevented_multiprocess = nose_gevented_multiprocess:GeventedMultiProcess'
+                'gevented_multiprocess = '
+                'nose_gevented_multiprocess:GeventedMultiProcess'
             ],
             'console_scripts': [
-                'nose_gevented_multiprocess_runner = nose_gevented_multiprocess:individual_client_starter'
+                'nose_gevented_multiprocess_runner = '
+                'nose_gevented_multiprocess:individual_client_starter'
             ]
         }
     )

--- a/tests/test_gevented_multiprocess.py
+++ b/tests/test_gevented_multiprocess.py
@@ -56,21 +56,21 @@ class TestingBaseServerAndClientComponents(GMultiplocessTestCase):
 
     def setUp(self):
         super(TestingBaseServerAndClientComponents, self).setUp()
-        self.queue_manager = gmultiprocess.TasksQueueManager()
+        self.queue_manager = gmultiprocess.TestsQueueManager()
 
     def test_queue_manager_get_task(self):
         queue_manager = self.queue_manager
 
-        queue_manager.tasks_queue.put('a')
-        queue_manager.tasks_queue.put('b')
+        queue_manager.tasks_queue.put(('a', None))
+        queue_manager.tasks_queue.put(('b', None))
 
         self.assertEqual(
             queue_manager._get_next_task(1),
-            'a'
+            ('a', None)
         )
         self.assertEqual(
             queue_manager['get_next_task'](1),
-            'b'
+            ('b', None)
         )
         self.assertEqual(
             queue_manager._get_next_task(1),
@@ -79,6 +79,13 @@ class TestingBaseServerAndClientComponents(GMultiplocessTestCase):
 
     def test_queue_manager_store_results(self):
         queue_manager = self.queue_manager
+
+        queue_manager.tasks_queue.put(('a', None))
+        queue_manager.tasks_queue.put(('b', None))
+
+        # Storing results depends on task timer having been started here:
+        queue_manager._get_next_task(1)
+        queue_manager._get_next_task(1)
 
         queue_manager._store_results(1, 'a')
         queue_manager['store_results'](1, 'b')
@@ -206,6 +213,8 @@ class TestingFullCycle(GMultiplocessTestCase):
 
         runner = gmultiprocess.GeventedMultiProcessTestRunner(stream=StringIO())
         runner.config.options.gevented_processes = 1
+        runner.config.options.gevented_timing_file = None
+        runner.config.options.gevented_timeout = 60
         result = runner.run(self.tests)
 
         self.assertEqual(

--- a/tests/test_gevented_multiprocess.py
+++ b/tests/test_gevented_multiprocess.py
@@ -103,6 +103,23 @@ class TestingBaseServerAndClientComponents(GMultiplocessTestCase):
             True
         )
 
+    def test_queue_manager_timing_out(self):
+        class Options(object):
+            gevented_timeout = .05
+
+        config = Config()
+        config.options = Options()
+        queue_manager = gmultiprocess.TestsQueueManager(config=config)
+
+        tasks = [gmultiprocess.get_task_key(('test_addr', 'arg'))]
+        with self.assertRaisesRegexp(Exception, 'Timing out'):
+            queue_manager.process_test_results(
+                tasks,
+                global_result=None,
+                output_stream=None,
+                stop_on_error=False,
+            )
+
 
 class MockRunnerClient(gmultiprocess.BaseTaskRunner):
 

--- a/tests/test_gevented_multiprocess_runner.py
+++ b/tests/test_gevented_multiprocess_runner.py
@@ -277,8 +277,7 @@ class TestingHelperFunctions(unittest.TestCase):
     def test_get_test_case_address(self):
         test = case.Test(TC('runTest'))
         address = gmultiprocess.get_test_case_address(test)
-
-        filename = os.path.abspath(os.path.join('.', __file__))
+        filename = os.path.abspath(os.path.join('.', __file__)).rstrip('c')
         should_be_address = filename + ':' + TC.__name__ + '.' + TC.runTest.__name__
 
         self.assertEqual(


### PR DESCRIPTION
This PR contains a number of changes and enhancements, some minor and some significant. See the individual commit messages for details. Summary:
1. --gevented-processes=1 should disable the plugin.
2. Make the amount of time the plugin waits for results configurable.
3. When tests take too long, give the user more information about what happened.
4. Add support for timing tests and running them from slowest to fastest to increase parallelization and decrease total test run time.
5. Logger name should be in the nose.plugins namespace for compatibility with nose's logging infrastructure.
